### PR TITLE
一度 CSV ファイルに出力したメッセージは、重複して出力しないようにする

### DIFF
--- a/db/migrate/1519612260_add_exported_at_to_messages.rb
+++ b/db/migrate/1519612260_add_exported_at_to_messages.rb
@@ -1,0 +1,8 @@
+class AddExportedAtToMessages < ActiveRecord::Migration[5.1]
+  def change
+    add_column :messages, :exported_at, :datetime
+    add_index :messages, [:exported_at, :sent_at]
+
+    remove_index :messages, :sent_at
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 1519218735) do
+ActiveRecord::Schema.define(version: 1519612260) do
 
   create_table "messages", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4" do |t|
     t.integer "room_id", null: false
@@ -22,7 +22,8 @@ ActiveRecord::Schema.define(version: 1519218735) do
     t.datetime "sent_at", precision: 6, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["sent_at"], name: "index_messages_on_sent_at"
+    t.datetime "exported_at"
+    t.index ["exported_at", "sent_at"], name: "index_messages_on_exported_at_and_sent_at"
     t.index ["uuid"], name: "index_messages_on_uuid", unique: true
   end
 

--- a/lib/tasks/history.thor
+++ b/lib/tasks/history.thor
@@ -57,7 +57,7 @@ module Task
         return say_abort
       end
 
-      FileUtils.rm_r(rooms_dir) if File.exist?(rooms_dir)
+      FileUtils.rm_rf(rooms_dir) if File.exist?(rooms_dir)
       say 'Room history JSON files are removed'
     end
 

--- a/lib/tasks/message.thor
+++ b/lib/tasks/message.thor
@@ -11,9 +11,9 @@ module Task
 
       say 'Exporting messages to CSV files ...'
 
-      ::Message.export_csv
+      messages_count = ::Message.export_csv
 
-      say 'Messages are exported to CSV files'
+      say "#{messages_count} messages are exported to CSV files"
     end
 
     desc 'clear', 'Remove messages CSV files'

--- a/spec/history_exporter_spec.rb
+++ b/spec/history_exporter_spec.rb
@@ -8,7 +8,7 @@ describe HistoryExporter do
     let(:to) { Time.zone.local(2017, 11, 7).end_of_day }
 
     after do
-      FileUtils.rm_r(Dir[File.join(History.rooms_dir, '*')])
+      FileUtils.rm_rf(Dir[File.join(History.rooms_dir, '*')])
     end
 
     it 'exports room history to JSON files' do
@@ -23,7 +23,7 @@ describe HistoryExporter do
     let(:to) { Time.zone.local(2018, 1, 2).end_of_day }
 
     after do
-      FileUtils.rm_r(Dir[File.join(History.rooms_dir, '*')])
+      FileUtils.rm_rf(Dir[File.join(History.rooms_dir, '*')])
     end
 
     it 'exports room history to JSON file' do

--- a/spec/lib/tasks/history_spec.rb
+++ b/spec/lib/tasks/history_spec.rb
@@ -4,7 +4,7 @@ describe Task::History do
     let!(:room2) { create(:room, id: 4337418) }
 
     after do
-      FileUtils.rm_r(Dir[File.join(History.rooms_dir, '*')])
+      FileUtils.rm_rf(Dir[File.join(History.rooms_dir, '*')])
     end
 
     context 'when theads option is NOT set' do

--- a/spec/lib/tasks/message_spec.rb
+++ b/spec/lib/tasks/message_spec.rb
@@ -5,7 +5,7 @@ describe Task::Message do
     end
 
     after do
-      FileUtils.rm_r(Dir[File.join(Message.dist_dir, '*')])
+      FileUtils.rm_rf(Dir[File.join(Message.dist_dir, '*')])
     end
 
     it 'exports messages to CSV files' do

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -13,5 +13,11 @@ describe Message do
         Message.export_csv
       }.to change { Dir[File.join(Message.dist_dir, '**/messages_*.csv')].size }
     end
+
+    it 'saves exported_at to messages' do
+      expect {
+        Message.export_csv
+      }.to change { Message.last.exported_at }
+    end
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -19,5 +19,9 @@ describe Message do
         Message.export_csv
       }.to change { Message.last.exported_at }
     end
+
+    it 'returns messages count' do
+      expect(Message.export_csv).to be > 0
+    end
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -5,7 +5,7 @@ describe Message do
     end
 
     after do
-      FileUtils.rm_r(Dir[File.join(Message.dist_dir, '*')])
+      FileUtils.rm_rf(Dir[File.join(Message.dist_dir, '*')])
     end
 
     it 'exports messages to CSV files' do

--- a/src/message.rb
+++ b/src/message.rb
@@ -33,11 +33,12 @@ class Message < ActiveRecord::Base
 
       loop do
         offset = (page - 1) * Message::BATCH_SIZE
-        messages = Message.includes(:room).order(:sent_at).offset(offset).limit(Message::BATCH_SIZE)
+        messages = Message.includes(:room).where(exported_at: nil).order(:sent_at).offset(offset).limit(Message::BATCH_SIZE)
 
         CSV.open(csv_path(current_dir: current_dir(current), page: page), 'w') do |csv|
           messages.each do |message|
             csv << [message.sent_at.to_i, message.room.name, message.sender_name, message.body]
+            message.update(exported_at: current)
           end
         end
 

--- a/src/message.rb
+++ b/src/message.rb
@@ -28,6 +28,7 @@ class Message < ActiveRecord::Base
     def export_csv
       current = Time.current
       page = 1
+      messages_count = Message.where(exported_at: nil).count
 
       FileUtils.mkdir_p(current_dir(current))
 
@@ -50,6 +51,8 @@ class Message < ActiveRecord::Base
           end
         end
       end
+
+      messages_count
 
     rescue => exception
       FileUtils.rm_rf(current_dir(current)) if Dir.exist?(current_dir(current))


### PR DESCRIPTION
一度 CSV ファイルに出力したメッセージは、重複して出力しないようにする。

* 重複して出力すると、重複して Slack にインポートされるため